### PR TITLE
Correct lookup NAPTR record

### DIFF
--- a/dns.inc.php
+++ b/dns.inc.php
@@ -404,6 +404,15 @@ class DNSQuery
 				
 				$string=$domain." TEXT \"".$data . "\" (in " . $string_count . " strings)";
 				break;
+				
+			case "NAPTR":
+				$buffer = $this->ReadResponse(4);
+				$extras = unpack("norder/npreference",$buffer);
+				$addonitial = $this->ReadDomainLabel();
+				$data = $this->ReadDomainLabel();
+				$extras['service']=$addonitial;
+				$string = $domain." NAPTR ".$data;
+				break;
 
 			default: // something we can't deal with
 				$stuff=$this->ReadResponse($ans_header['length']);


### PR DESCRIPTION
Test using apple.com or columbia.edu

Example:

NAPTR (# 35)
record data:	_sips._tcp.apple.com
record ttl:	21026
order:	50
preference:	50
service:	se.SIPS+D2T
 
NAPTR (# 35)
record data:	_sip._udp.apple.com
record ttl:	21026
order:	100
preference:	50
service:	se.SIP+D2U
 
NAPTR (# 35)
record data:	_sip._tcp.apple.com
record ttl:	21026
order:	90
preference:	50
service:	se.SIP+D2T

