### PR TITLE
Fixes an issue where an ErrorException may occur

### DIFF
--- a/src/PurplePixie/PhpDns/DNSQuery.php
+++ b/src/PurplePixie/PhpDns/DNSQuery.php
@@ -356,7 +356,7 @@ class DNSQuery
                 $buffer = $this->readResponse(20);
                 $extras = unpack('Nserial/Nrefresh/Nretry/Nexpiry/Nminttl', $buffer); // butfix to NNNNN from nnNNN for 1.01
                 $dot = strpos($responsible, '.');
-                if($dot){
+                if($dot !== false){
                     $responsible[$dot] = '@';
                 }
                 $extras['responsible'] = $responsible;

--- a/src/PurplePixie/PhpDns/DNSQuery.php
+++ b/src/PurplePixie/PhpDns/DNSQuery.php
@@ -356,7 +356,9 @@ class DNSQuery
                 $buffer = $this->readResponse(20);
                 $extras = unpack('Nserial/Nrefresh/Nretry/Nexpiry/Nminttl', $buffer); // butfix to NNNNN from nnNNN for 1.01
                 $dot = strpos($responsible, '.');
-                $responsible[$dot] = '@';
+                if($dot){
+                    $responsible[$dot] = '@';
+                }
                 $extras['responsible'] = $responsible;
                 $string = $domain . ' SOA ' . $data . ' Serial ' . $extras['serial'];
                 break;


### PR DESCRIPTION
Only attempt to replace the '.' in the SOA responsible, if the dot exists. 

Ex: ubl.unsubscore.com has a responsible property of 'hostmaster', causing an exception.